### PR TITLE
savefig() error fixed

### DIFF
--- a/face_Recognition.py
+++ b/face_Recognition.py
@@ -90,8 +90,9 @@ r = model.fit_generator(
 plt.plot(r.history['loss'], label='train loss')
 plt.plot(r.history['val_loss'], label='val loss')
 plt.legend()
+plt.savefig('LossVal_loss.png')
 plt.show()
-plt.savefig('LossVal_loss')
+
 
 # accuracies
 plt.plot(r.history['acc'], label='train acc')


### PR DESCRIPTION
In this, savefig() must comes first before plt.show() because if plt.show() is executed then at that point matplotlib resets and that graph data is no more so when the graph is saved in the current directory its just literally blank one.
So, to save the actual graph savefig must use before plt.show()
Hope, you solve this problem