### PR TITLE
fit_generator() is no more maintained

### DIFF
--- a/face_Recognition.py
+++ b/face_Recognition.py
@@ -79,8 +79,8 @@ test_set = test_datagen.flow_from_directory('Datasets/Test',
                          nb_val_samples = 2000)'''
 
 # fit the model
-r = model.fit_generator(
-  training_set,
+r = model.fit(
+  x=training_set,
   validation_data=test_set,
   epochs=5,
   steps_per_epoch=len(training_set),
@@ -94,8 +94,8 @@ plt.show()
 plt.savefig('LossVal_loss')
 
 # accuracies
-plt.plot(r.history['acc'], label='train acc')
-plt.plot(r.history['val_acc'], label='val acc')
+plt.plot(r.history['accuracy'], label='train acc')
+plt.plot(r.history['val_accuracy'], label='val acc')
 plt.legend()
 plt.show()
 plt.savefig('AccVal_acc')


### PR DESCRIPTION
fit_generator() is no more maintained by keras, they always suggests us to use `fit()` method instead of `fit_generator() `because fit_generator() is no more maintained by them.
Also, in the history dict that comes from r.history
`r.history['acc']` is not there `r.history['accuracy']` is there
`r.history['val_acc']` is not there `r.history['val_accuracy']` is there

```
{'loss': [0.5364223122596741,
  0.4704432785511017,
  0.45543161034584045,
  0.442967027425766,
  0.432258665561676],
 'accuracy': [0.7246249914169312,
  0.7758749723434448,
  0.7861250042915344,
  0.7906249761581421,
  0.7956249713897705],
 'val_loss': [0.46301984786987305,
  0.4526628255844116,
  0.44189468026161194,
  0.43687668442726135,
  0.43237316608428955],
 'val_accuracy': [0.7799999713897705,
  0.7864999771118164,
  0.7935000061988831,
  0.7910000085830688,
  0.7914999723434448]}
```
Prefer the keys of this history dict.
Else, all your contribution is appreciated by us.
Hope, you will understand this 

Thanks a lot,
HaPpY Coding 😇